### PR TITLE
Improvement to the timings margins if a char starts just after CTS dropped

### DIFF
--- a/HostFS/6502src.txt
+++ b/HostFS/6502src.txt
@@ -2431,8 +2431,8 @@ NEXT
 \ interval from 6us to 5us. (i.e. 4,6,4,4 becomes 4,5,5,4)
 	ASL	upiob		\ (3 + 7)
 	LDA	upiob		\ (3 + 3)
-	BCS	T2		\ (2) or (3)
-	BMI	T1		\ (2) or (3)
+	BCS	T3		\ (2) or (3)
+	BMI	T2		\ (2) or (3)
 	LDA	upiob		\ (3 + 3)
 	BMI	T1		\ (2) or (3)
 FOR	N, 1, 10
@@ -2450,11 +2450,11 @@ NEXT
 \ but only ever drops CTS.
 
 .T0	CPX	#bufsize	\ (2)  (2)
-	BCS	xcts		\ (2)  (3)
-.T1	NOP			\ (2)
+.T1	BCS	xcts		\ (2)  (3)
+.T2	NOP			\ (2)
 	NOP			\ (2)
 	NOP			\ (2)
-.T2	LDA	#0		\ (2)
+.T3	LDA	#0		\ (2)
 	BEQ	xskip		\ (3)
 .xcts
 	NOP			\      (2)


### PR DESCRIPTION
Hi Stephen,

I've been doing some more testing of the "hoglet-core" branch of HostHF, particularly coping with the race condition where CTS is dropped. Normally this race condition happens very infrequently. But with the Device::SerialPort drivers and the added delays it happens much more regularly. The timing was very tight, and I was seeing occasional data corruption with your SAVE/LOAD basic test (maybe 5 corruptions in the run of 1000 SAVE/LOAD cycles).

Anyway, after some very careful cycle counting, I've been able to improve this.

Before this change:
![img_1310](https://user-images.githubusercontent.com/1951463/38454231-303c2512-3a5b-11e8-92e9-1ffcdc4b6e7d.JPG)

After this change:
![img_1311](https://user-images.githubusercontent.com/1951463/38454234-387772cc-3a5b-11e8-8e60-66d982be3e93.JPG)

The line marked D7 is the receive data, zooming in on just one bit. (I'm loading a file that contains just &50 bytes, so the scope triggers very consistently).

The line marked D5 is the 6522 chip select, showing you the range of when this is sampled. The scope is in infinite persistence mode, and has accumulated ~10mins of data in each case.

You can see the sampling window is much tighter with this change applied.

I've tested this pretty well, and it also only affects the code path where this race condition occurs.

Dave